### PR TITLE
Fix/product price in cents

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "sequra-promotions",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "title": "SeQura Promotions",
   "description": "List the promotions available for your SeQura payment",
   "builders": {

--- a/react/components/PromotionsList.tsx
+++ b/react/components/PromotionsList.tsx
@@ -25,8 +25,10 @@ const PromotionsList: FC<PromotionsListProps> = ({
     return null
   }
 
+  const priceInCents = +(selectedPrice * 100).toFixed(0)
+
   const promotionsList = products.map((product: string) => (
-    <Promotion key={product} product={product} amount={selectedPrice} />
+    <Promotion key={product} product={product} amount={priceInCents} />
   ))
 
   const listContextValue = list.concat(promotionsList)


### PR DESCRIPTION
### What this PR fixes
There was a bug preventing the widgets from being displayed when a products price had `00` cents, for example `59.00`.
The SeQura script expects to receive this amount in cents (5900 for the example given).